### PR TITLE
Implemented basic CLI tool

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1,0 +1,19 @@
+# This is an example configuration file for lnurl command
+# In this case we use the internal `lnd_rest` RPC implementation
+# If you've installed a package that allows a different implementation
+# refer to their documentation
+
+# Whether channels accepted by LNURL-channel should be private
+# The default is false. (All channels are public.)
+private_channels = false
+
+# RPC implementation - there is built-in implementation using LND REST
+# You can implement your own by implementing LnRPC protocol from cli module
+# and provide it using entry point (see setup.py)
+rpc_proto = "lnd_rest"
+
+# The configuration data for 
+[rpc]
+macaroon_file = "/var/lib/lnd-system-mainnet/private/admin.macaroon"
+tls_cert_file = "/var/lib/lnd-system-mainnet/public/tls.cert"
+address = "127.0.0.1:9090"

--- a/lnurl/cli/__init__.py
+++ b/lnurl/cli/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 import sys
 import pkg_resources
 from contextlib import contextmanager
@@ -16,13 +14,6 @@ try:
     from typing import Mapping, Any  # type: ignore
 except ImportError:  # pragma: nocover
     from typing_extensions import Mapping, Any  # type: ignore
-
-# We want to support Python 3.7, so we have to define it ourselves
-def remove_prefix(string: str, prefix: str):
-    if string.startswith(prefix):
-        return string[len(prefix):]
-    else:
-        return string
 
 class Context:
     """Contains RPC handler with settings"""

--- a/lnurl/cli/__init__.py
+++ b/lnurl/cli/__init__.py
@@ -1,0 +1,154 @@
+#!/usr/bin/python3
+
+import sys
+import pkg_resources
+from contextlib import contextmanager
+from lnurl.models import LnurlResponseModel, LnurlChannelResponse, LnurlSuccessResponse, LnurlErrorResponse
+from lnurl.exceptions import LnurlException, LnurlResponseException
+from lnurl.core import handle as handle_lnurl
+from lnurl.core import get as get_lnurl
+from lnurl.cli.lnrpc import LnRPC
+import click
+import toml
+from typing import Generator
+
+try:
+    from typing import Mapping, Any  # type: ignore
+except ImportError:  # pragma: nocover
+    from typing_extensions import Mapping, Any  # type: ignore
+
+# We want to support Python 3.7, so we have to define it ourselves
+def remove_prefix(string: str, prefix: str):
+    if string.startswith(prefix):
+        return string[len(prefix):]
+    else:
+        return string
+
+class Context:
+    """Contains RPC handler with settings"""
+
+    # 0 - public, 1 - private, public by default
+    _channel_type: int = 0
+    _rpc: LnRPC
+
+    def __init__(self, rpc: LnRPC):
+        self._rpc = rpc
+
+    def load_settings(self, config: Mapping[str, Any]):
+        """Loads settings from a dictionary
+
+        So far there's only one setting: private_channels: bool
+        """
+
+        try:
+            if config["private_channels"]:
+                self._channel_type = 1
+        except KeyError:
+            pass
+
+    def handle_url(self, url: str):
+        """Processes given LNURL"""
+
+        if url.startswith("lightning:"):
+            url = url[len("lightning"):]
+        elif url.startswith("lnurl"):
+            url = url[len("lnurl"):]
+
+        response = handle_lnurl(url)
+        self._dispatch(response)
+
+    def _dispatch(self, response: LnurlResponseModel):
+        """Decides following steps based on the response"""
+
+        if isinstance(response, LnurlChannelResponse):
+            self._accept_channel(response)
+        elif isinstance(response, LnurlErrorResponse):
+            raise LnurlException("Error returned by the LNURL server: %s" % response.reason)
+        else:
+            raise LnurlException("Error: LNURL subprotocol %s not implemented" % type(response).__name__)
+
+    def _accept_channel(self, response: LnurlChannelResponse):
+        """Handles accepting a channel"""
+
+        node_id = self._rpc.get_node_id()
+        callback = response.callback
+        query = "k1=%s&remoteid=%s&private=%d" % (response.k1, node_id, self._channel_type)
+
+        if callback.query is None:
+            new_uri = "%s?%s" % (callback, query)
+        else:
+            new_uri = "%s&%s" % (callback, query)
+
+        self._rpc.connect(response.uri)
+        result = get_lnurl(new_uri)
+
+        if isinstance(result, LnurlErrorResponse):
+            raise LnurlResponseException("Failed to accept a channel: %s" % result.reason)
+        elif not isinstance(result, LnurlSuccessResponse):
+            raise LnurlResponseException("Error: Unexpected result from the server")
+
+    def close(self):
+        """Closes all associated resources"""
+
+        self._rpc.close()
+
+def _load_rpc_entry_point(rpc_proto: str):
+    """Loads entry point for given RPC protocol"""
+
+    entry_points = pkg_resources.iter_entry_points("lnurl.rpc_handlers", rpc_proto)
+    try:
+        handler_entry_point = next(entry_points)
+        return handler_entry_point.load()
+    except StopIteration:
+        raise LnurlException("Unknown LN RPC protocol: %s" % rpc_proto)
+
+    # Warn the user if more than one RPC implementation exists
+    try:
+        next(entry_points)
+        print("Warning: more than one implementation for %s exists, picking the first one" % rpc_proto, file=sys.stderr)
+    except StopIteration:
+        pass
+
+@contextmanager
+def _get_config(file_name: str) -> Generator[Context, None, None]:
+    with open(file_name, "r") as config_file:
+        config = toml.load(config_file)
+
+    rpc_proto = config["rpc_proto"]
+
+    rpc = _load_rpc_entry_point(rpc_proto)(config["rpc"])
+
+    context = Context(rpc)
+
+    try:
+        context.load_settings(config)
+        yield context
+    finally:
+        context.close()
+
+@click.command()
+@click.option("--config", help="Configuration file path", required=True)
+# Can't figure out how to detect if this option was present, so keeping it
+# commented to not confuse the users
+#@click.option("--private-channels", "channel_type", help="Request accepted channels to be private", flag_value = 1)
+#@click.option("--public-channels", "channel_type", help="Request accepted channels to be public. This is the default.", flag_value = 0)
+def lnurl(config: str):
+    """Entry point - the lnurl command"""
+
+    had_errors = False
+    try:
+        with _get_config(config) as context:
+            for line in sys.stdin.readlines():
+                url = line.strip()
+                try:
+                    context.handle_url(url)
+                except Exception as exception:
+                    print("Failed to handle URL %s: %s" % (url, str(exception)), file=sys.stderr)
+                    had_errors = True
+
+    except Exception as exception:
+        print("Failed to load configuration: %s" % str(exception), file=sys.stderr)
+        had_errors = True
+
+    if had_errors:
+        sys.exit(1)

--- a/lnurl/cli/__init__.py
+++ b/lnurl/cli/__init__.py
@@ -55,8 +55,8 @@ class Context:
             self._accept_channel(response)
         elif isinstance(response, LnurlErrorResponse):
             raise LnurlException("Error returned by the LNURL server: %s" % response.reason)
-        else:
-            raise LnurlException("Error: LNURL subprotocol %s not implemented" % type(response).__name__)
+
+        raise LnurlException("Error: LNURL subprotocol %s not implemented" % type(response).__name__)
 
     def _accept_channel(self, response: LnurlChannelResponse):
         """Handles accepting a channel"""
@@ -75,7 +75,7 @@ class Context:
 
         if isinstance(result, LnurlErrorResponse):
             raise LnurlResponseException("Failed to accept a channel: %s" % result.reason)
-        elif not isinstance(result, LnurlSuccessResponse):
+        if not isinstance(result, LnurlSuccessResponse):
             raise LnurlResponseException("Error: Unexpected result from the server")
 
     def close(self):

--- a/lnurl/cli/lnrpc/__init__.py
+++ b/lnurl/cli/lnrpc/__init__.py
@@ -1,0 +1,34 @@
+try:
+    from typing import Protocol
+except ImportError:  # pragma: nocover
+    from typing_extensions import Protocol # type: ignore
+
+from lnurl.types import LightningNodeUri
+
+class LnRPC(Protocol):
+    """Protocol defining the interface with LN node implementations.
+    
+    Implementors of this protocol can be used to execute the LNURL actions.
+    """
+
+    def close(self):
+        """Closes RPC session.
+
+        All method calls after a call to this methods are invalid.
+
+        Warning: do NOT confuse with closing a channel!
+        """
+        pass
+
+    def get_node_id(self) -> str:
+        """Returns the ID (hex-encoded public key) of the node"""
+        pass
+
+    def connect(self, node: LightningNodeUri):
+        """Instructs the node to connect to a remote peer.
+        
+        Warning: Do NOT confuse with connecting to RPC server! Connecting to the
+        RPC server is implementation-specific, this is a command for a node to
+        connect to another node.
+        """
+        pass

--- a/lnurl/cli/lnrpc/__init__.py
+++ b/lnurl/cli/lnrpc/__init__.py
@@ -18,11 +18,9 @@ class LnRPC(Protocol):
 
         Warning: do NOT confuse with closing a channel!
         """
-        pass
 
     def get_node_id(self) -> str:
         """Returns the ID (hex-encoded public key) of the node"""
-        pass
 
     def connect(self, node: LightningNodeUri):
         """Instructs the node to connect to a remote peer.
@@ -31,4 +29,3 @@ class LnRPC(Protocol):
         RPC server is implementation-specific, this is a command for a node to
         connect to another node.
         """
-        pass

--- a/lnurl/cli/lnrpc/lnd_rest.py
+++ b/lnurl/cli/lnrpc/lnd_rest.py
@@ -1,0 +1,94 @@
+from lnurl.cli import LnRPC
+from lnurl.types import LightningNodeUri
+import requests
+from enum import Enum
+
+try:
+    from typing import Mapping, Any, Optional  # type: ignore
+except ImportError:  # pragma: nocover
+    from typing_extensions import Mapping, Any, Optional  # type: ignore
+
+class HTTPMethod(Enum):
+    GET = "GET"
+    POST = "POST"
+
+class UnexpectedHttpStatusException(Exception):
+    """Thrown when LND returns something else than 200"""
+
+    status_code: int
+    method: str
+    error: Optional[str]
+
+    def __init__(self, status_code: int, method, error: Optional[str]):
+        self.status_code = status_code
+        self.method = method
+        self.error = error
+
+        if self.error is None:
+            super().__init__("Unexpected LND HTTP status: %d, method: %s" % (self.status_code, self.method))
+        else:
+            super().__init__("Unexpected LND HTTP status: %d, method: %s, error message: %s" % (self.status_code, self.method, self.error))
+
+class LndRestRPC(LnRPC):
+    """RPC handler using LND REST API"""
+
+    _rest_address: str
+    _session: requests.Session
+
+    # We cache node ID because it doesn't change
+    _node_id: Optional[str] = None
+
+    def __init__(self, config: Mapping[str, Any]):
+        self._rest_address = config["address"]
+
+        # We load the file at init to catch possible errors ASAP and also
+        # to avoid re-loading it if the same instance is used for multiple calls.
+        with open(config["macaroon_file"], "rb") as macaroon_file:
+            macaroon = macaroon_file.read().hex()
+
+        headers = { "Grpc-Metadata-macaroon": macaroon }
+
+        self._session = requests.Session()
+        self._session.headers.update(headers)
+        self._session.verify = config["tls_cert_file"]
+
+    def _call(self, http_method: HTTPMethod, rpc_method: str, data: Optional[Mapping["str", Any]] = None):
+        """Calls specific method of LND with given arguments"""
+
+        url = "https://%s/v1/%s" % (self._rest_address, rpc_method)
+        request = requests.Request(http_method.value, url, json=data)
+
+        prepared = self._session.prepare_request(request)
+        response = self._session.send(prepared)
+
+        if response.status_code != 200:
+            try:
+                resp_json = response.json()
+                error = resp_json["error"]
+            except:
+                error = None
+
+            raise UnexpectedHttpStatusException(response.status_code, rpc_method, error)
+
+        return response.json()
+
+    def close(self):
+        self._session.close()
+
+    def get_node_id(self) -> str:
+        if self._node_id is None:
+            self._node_id = self._call(HTTPMethod.GET, "getinfo")["identity_pubkey"]
+
+        return self._node_id
+
+    def connect(self, node: LightningNodeUri):
+        if node.port is None:
+            host = node.ip
+        else:
+            host = "%s:%s" % (node.ip, node.port)
+
+        try:
+            self._call(HTTPMethod.POST, "peers", { "addr": { "pubkey": node.key, "host": host }, "perm": False })
+        except UnexpectedHttpStatusException as e:
+            if e.error is None or not e.error.startswith("already connected to peer"):
+                raise e

--- a/lnurl/cli/lnrpc/lnd_rest.py
+++ b/lnurl/cli/lnrpc/lnd_rest.py
@@ -65,7 +65,7 @@ class LndRestRPC(LnRPC):
             try:
                 resp_json = response.json()
                 error = resp_json["error"]
-            except:
+            except Exception:
                 error = None
 
             raise UnexpectedHttpStatusException(response.status_code, rpc_method, error)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from os import path
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 with open(path.join(path.abspath(path.dirname(__file__)), "README.md")) as f:
@@ -31,8 +31,13 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Topic :: Utilities",
     ],
-    packages=["lnurl"],
+    packages=find_packages(exclude=["tests"]),
     python_requires=">=3.6",
     install_requires=["bech32", "pydantic", "typing-extensions; python_version<'3.8'"],
+    extras_require={ "cli": ["click", "toml", "requests"] },
+    entry_points={
+        "console_scripts": [ "lnurl = lnurl.cli:lnurl [cli]" ],
+        "lnurl.rpc_handlers": [ "lnd_rest = lnurl.cli.lnrpc.lnd_rest:LndRestRPC [cli]" ]
+    },
     zip_safe=False,
 )


### PR DESCRIPTION
This implements a simple command line tool that can perform
`lnurl-channel` using configured LND node (with LND REST). While `lnurl`
is much more than just channel, other features should be fairly easy to
implement after this commit.

Implementation notes
--------------------

* RPC handler uses dependency inversion principle (AKA clean
  architecture) to make it easy to implement other RPC protocols
  (Eclair, clightning)
* RPC handler is loaded using `entry_points` mechanism, which makes it
  easy to implement new handlers in different packages (just implement
  the protocol and register the entry point)
* cli is executed using `entry_points` mechanism, which seesm to be
  idiomatic and does the right thing with regards to shebangs etc.
* The configuration is loaded from a configuration file. This is to
  avoid awkward options on command line and if there's an implemetation
  working directly with secrets, it avoids passing them on command line,
  which would be innsecure
* The URLs are entered using `stdin` this is intentional design as LNURL
  contains a secret that would be readable if it was an argument.
* `click` is used for argument parsing as was suggested in the related
  issue
* The *new code* passes `mypy` without errors or warnings

Closes #3