### PR TITLE
Call raise_for_exception() when fetching url

### DIFF
--- a/lnurl/core.py
+++ b/lnurl/core.py
@@ -26,14 +26,22 @@ def encode(url: str) -> Lnurl:
         raise InvalidUrl
 
 
-def get(url: str, *, response_class: Optional[Any] = None, verify: Union[str, bool] = True) -> LnurlResponseModel:
+def get(
+    url: str,
+    *,
+    response_class: Optional[Any] = None,
+    verify: Union[str, bool] = True,
+    raise_for_status: Optional[bool] = True
+) -> LnurlResponseModel:
     if requests is None:  # pragma: nocover
         raise ImportError("The `requests` library must be installed to use `lnurl.get()` and `lnurl.handle()`.")
 
     try:
         r = requests.get(url, verify=verify)
+        if raise_for_status:
+            r.raise_for_status()
     except Exception as e:
-        raise LnurlResponseException(str(e))
+        raise LnurlResponseException(e)
 
     if response_class:
         assert issubclass(response_class, LnurlResponseModel), "Use a valid `LnurlResponseModel` subclass."


### PR DESCRIPTION
At the moment, if the response contains an error status (400, 500, etc), the code will not raise the proper exception. Instead, it will raise a pydantic missing field error from this line: `return response_class(**r.json())`, which is misleading.

This pull request makes the code raise an exception if there was an issue in `requests.get()`, and will also include the exception object (`raise LnurlResponseException(e)`) which contains the response text, instead of just containing a one line error message like it has at the moment (`raise LnurlResponseException(str(e))`).