### PR TITLE
Add a comment_allowed field to LnurlPayResponse

### DIFF
--- a/lnurl/models.py
+++ b/lnurl/models.py
@@ -108,6 +108,11 @@ class LnurlPayResponse(LnurlResponseModel):
     min_sendable: MilliSatoshi = Field(..., alias="minSendable")
     max_sendable: MilliSatoshi = Field(..., alias="maxSendable")
     metadata: LnurlPayMetadata
+    comment_allowed: Optional[int] = Field(
+        1000,
+        description="Length of comment which can be sent",
+        alias="commentAllowed",
+    )
 
     @validator("max_sendable")
     def max_less_than_min(cls, value, values, **kwargs):  # noqa

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,14 +1,14 @@
 import json
-
 import pytest
+
 from pydantic import ValidationError
 
 from lnurl.models import (
-    LnurlChannelResponse,
     LnurlErrorResponse,
+    LnurlSuccessResponse,
+    LnurlChannelResponse,
     LnurlHostedChannelResponse,
     LnurlPayResponse,
-    LnurlSuccessResponse,
     LnurlWithdrawResponse,
 )
 
@@ -23,7 +23,7 @@ class TestLnurlErrorResponse:
 
     def test_no_reason(self):
         with pytest.raises(ValidationError):
-            LnurlErrorResponse()  # type: ignore
+            LnurlErrorResponse()
 
 
 class TestLnurlSuccessResponse:
@@ -80,13 +80,6 @@ class TestLnurlPayResponse:
         [
             {"callback": "https://service.io/pay", "min_sendable": 1000, "max_sendable": 2000, "metadata": metadata},
             {"callback": "https://service.io/pay", "minSendable": 1000, "maxSendable": 2000, "metadata": metadata},
-            {
-                "callback": "https://service.io/pay",
-                "minSendable": 1000,
-                "maxSendable": 2000,
-                "metadata": metadata,
-                "commentAllowed": True,
-            },
         ],
     )
     def test_success_response(self, d):
@@ -127,13 +120,6 @@ class TestLnurlPayResponse:
             {"callback": "https://service.io/pay", "min_sendable": 0, "max_sendable": 0, "metadata": metadata},  # 0
             {"callback": "https://service.io/pay", "minSendable": 100, "maxSendable": 10, "metadata": metadata},  # max
             {"callback": "https://service.io/pay", "minSendable": -90, "maxSendable": -10, "metadata": metadata},
-            {
-                "callback": "https://service.io/pay",
-                "minSendable": 10,
-                "maxSendable": 1000,
-                "metadata": metadata,
-                "commentAllowed": "blobby",
-            },
         ],
     )
     def test_invalid_data(self, d):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,14 +1,14 @@
 import json
-import pytest
 
+import pytest
 from pydantic import ValidationError
 
 from lnurl.models import (
-    LnurlErrorResponse,
-    LnurlSuccessResponse,
     LnurlChannelResponse,
+    LnurlErrorResponse,
     LnurlHostedChannelResponse,
     LnurlPayResponse,
+    LnurlSuccessResponse,
     LnurlWithdrawResponse,
 )
 
@@ -23,7 +23,7 @@ class TestLnurlErrorResponse:
 
     def test_no_reason(self):
         with pytest.raises(ValidationError):
-            LnurlErrorResponse()
+            LnurlErrorResponse()  # type: ignore
 
 
 class TestLnurlSuccessResponse:
@@ -80,6 +80,13 @@ class TestLnurlPayResponse:
         [
             {"callback": "https://service.io/pay", "min_sendable": 1000, "max_sendable": 2000, "metadata": metadata},
             {"callback": "https://service.io/pay", "minSendable": 1000, "maxSendable": 2000, "metadata": metadata},
+            {
+                "callback": "https://service.io/pay",
+                "minSendable": 1000,
+                "maxSendable": 2000,
+                "metadata": metadata,
+                "commentAllowed": True,
+            },
         ],
     )
     def test_success_response(self, d):
@@ -120,6 +127,13 @@ class TestLnurlPayResponse:
             {"callback": "https://service.io/pay", "min_sendable": 0, "max_sendable": 0, "metadata": metadata},  # 0
             {"callback": "https://service.io/pay", "minSendable": 100, "maxSendable": 10, "metadata": metadata},  # max
             {"callback": "https://service.io/pay", "minSendable": -90, "maxSendable": -10, "metadata": metadata},
+            {
+                "callback": "https://service.io/pay",
+                "minSendable": 10,
+                "maxSendable": 1000,
+                "metadata": metadata,
+                "commentAllowed": "blobby",
+            },
         ],
     )
     def test_invalid_data(self, d):


### PR DESCRIPTION
Signed-off-by: Brian of London (Dot) <brian@v4v.app>

I added one extra field to this structure. I don't have the capacity to get a whole test environment up and running but I'm pretty sure this one extra field doesn't break anything.

My code actually over-rides this class:

```
class LnurlResponse(LnurlPayResponse):
    """Adds comment_allowed to the LnurlPayResponse"""

    comment_allowed: Optional[int] = Field(
        1000,
        description="Length of comment which can be sent",
        alias="commentAllowed",
    )
```

This is necessary for specifying the `commentAllowed` field in the output of a call too this:

`https://api.v4v.app/docs#/lnurl/lnurlp__well_known_lnurlp__hive_accname__get`

