### PR TITLE
Adds comment_allowed to LnurlPayResponse with a new class LnurlPayResponseComment

### DIFF
--- a/lnurl/__init__.py
+++ b/lnurl/__init__.py
@@ -13,6 +13,7 @@ from .models import (
     LnurlChannelResponse,
     LnurlHostedChannelResponse,
     LnurlPayResponse,
+    LnurlPayResponseComment,
     LnurlPayActionResponse,
     LnurlWithdrawResponse,
 )

--- a/lnurl/models.py
+++ b/lnurl/models.py
@@ -1,13 +1,10 @@
 import math
+from typing import List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field, validator
-from typing import List, Optional, Union
-
-from typing import Literal, Union
 
 from .exceptions import LnurlResponseException
 from .types import (
-    OnionUrl,
     ClearnetUrl,
     DebugUrl,
     InitializationVector,
@@ -16,6 +13,7 @@ from .types import (
     LnurlPayMetadata,
     Max144Str,
     MilliSatoshi,
+    OnionUrl,
 )
 
 
@@ -106,11 +104,6 @@ class LnurlPayResponse(LnurlResponseModel):
     min_sendable: MilliSatoshi = Field(..., alias="minSendable")
     max_sendable: MilliSatoshi = Field(..., alias="maxSendable")
     metadata: LnurlPayMetadata
-    comment_allowed: Optional[int] = Field(
-        1000,
-        description="Length of comment which can be sent",
-        alias="commentAllowed",
-    )
 
     @validator("max_sendable")
     def max_less_than_min(cls, value, values, **kwargs):  # noqa
@@ -125,6 +118,19 @@ class LnurlPayResponse(LnurlResponseModel):
     @property
     def max_sats(self) -> int:
         return int(math.floor(self.max_sendable / 1000))
+
+
+class LnurlPayResponseComment(LnurlPayResponse):
+    """
+    Adds the optional comment_allowed field to the LnurlPayResponse
+    ref LUD-12: Comments in payRequest.
+    """
+
+    comment_allowed: int = Field(
+        1000,
+        description="Length of comment which can be sent",
+        alias="commentAllowed",
+    )
 
 
 class LnurlPayActionResponse(LnurlResponseModel):

--- a/lnurl/models.py
+++ b/lnurl/models.py
@@ -106,6 +106,11 @@ class LnurlPayResponse(LnurlResponseModel):
     min_sendable: MilliSatoshi = Field(..., alias="minSendable")
     max_sendable: MilliSatoshi = Field(..., alias="maxSendable")
     metadata: LnurlPayMetadata
+    comment_allowed: Optional[int] = Field(
+        1000,
+        description="Length of comment which can be sent",
+        alias="commentAllowed",
+    )
 
     @validator("max_sendable")
     def max_less_than_min(cls, value, values, **kwargs):  # noqa

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,14 +1,15 @@
 import json
-import pytest
 
+import pytest
 from pydantic import ValidationError
 
 from lnurl.models import (
-    LnurlErrorResponse,
-    LnurlSuccessResponse,
     LnurlChannelResponse,
+    LnurlErrorResponse,
     LnurlHostedChannelResponse,
     LnurlPayResponse,
+    LnurlPayResponseComment,
+    LnurlSuccessResponse,
     LnurlWithdrawResponse,
 )
 
@@ -23,7 +24,7 @@ class TestLnurlErrorResponse:
 
     def test_no_reason(self):
         with pytest.raises(ValidationError):
-            LnurlErrorResponse() #type: ignore
+            LnurlErrorResponse()  # type: ignore
 
 
 class TestLnurlSuccessResponse:
@@ -90,8 +91,7 @@ class TestLnurlPayResponse:
             == res.json(by_alias=True)
             == (
                 f'{{"tag": "payRequest", "callback": "https://service.io/pay", '
-                f'"minSendable": 1000, "maxSendable": 2000, "metadata": {json.dumps(metadata)}, '
-                f'"commentAllowed": 1000}}'
+                f'"minSendable": 1000, "maxSendable": 2000, "metadata": {json.dumps(metadata)}}}'
             )
         )
         assert (
@@ -103,7 +103,6 @@ class TestLnurlPayResponse:
                 "minSendable": 1000,
                 "maxSendable": 2000,
                 "metadata": metadata,
-                "commentAllowed": 1000
             }
         )
         assert res.dict(by_alias=False) == {
@@ -112,7 +111,6 @@ class TestLnurlPayResponse:
             "min_sendable": 1000,
             "max_sendable": 2000,
             "metadata": metadata,
-            "comment_allowed": 1000
         }
 
     @pytest.mark.parametrize(
@@ -128,6 +126,62 @@ class TestLnurlPayResponse:
     def test_invalid_data(self, d):
         with pytest.raises(ValidationError):
             LnurlPayResponse(**d)
+
+
+class TestLnurlPayResponseComment:
+    @pytest.mark.parametrize(
+        "d",
+        [
+            {"callback": "https://service.io/pay", "min_sendable": 1000, "max_sendable": 2000, "metadata": metadata},
+            {"callback": "https://service.io/pay", "minSendable": 1000, "maxSendable": 2000, "metadata": metadata},
+        ],
+    )
+    def test_success_response(self, d):
+        res = LnurlPayResponseComment(**d)
+        assert res.ok
+        assert (
+            res.json()
+            == res.json(by_alias=True)
+            == (
+                f'{{"tag": "payRequest", "callback": "https://service.io/pay", '
+                f'"minSendable": 1000, "maxSendable": 2000, "metadata": {json.dumps(metadata)}, '
+                f'"commentAllowed": 1000}}'
+            )
+        )
+        assert (
+            res.dict()
+            == res.dict(by_alias=True)
+            == {
+                "tag": "payRequest",
+                "callback": "https://service.io/pay",
+                "minSendable": 1000,
+                "maxSendable": 2000,
+                "metadata": metadata,
+                "commentAllowed": 1000,
+            }
+        )
+        assert res.dict(by_alias=False) == {
+            "tag": "payRequest",
+            "callback": "https://service.io/pay",
+            "min_sendable": 1000,
+            "max_sendable": 2000,
+            "metadata": metadata,
+            "comment_allowed": 1000,
+        }
+
+    @pytest.mark.parametrize(
+        "d",
+        [
+            {"callback": "invalid", "min_sendable": 1000, "max_sendable": 2000, "metadata": metadata},
+            {"callback": "https://service.io/pay"},  # missing fields
+            {"callback": "https://service.io/pay", "min_sendable": 0, "max_sendable": 0, "metadata": metadata},  # 0
+            {"callback": "https://service.io/pay", "minSendable": 100, "maxSendable": 10, "metadata": metadata},  # max
+            {"callback": "https://service.io/pay", "minSendable": -90, "maxSendable": -10, "metadata": metadata},
+        ],
+    )
+    def test_invalid_data(self, d):
+        with pytest.raises(ValidationError):
+            LnurlPayResponseComment(**d)
 
 
 class TestLnurlWithdrawResponse:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -90,7 +90,8 @@ class TestLnurlPayResponse:
             == res.json(by_alias=True)
             == (
                 f'{{"tag": "payRequest", "callback": "https://service.io/pay", '
-                f'"minSendable": 1000, "maxSendable": 2000, "metadata": {json.dumps(metadata)}}}'
+                f'"minSendable": 1000, "maxSendable": 2000, "metadata": {json.dumps(metadata)}, '
+                f'"commentAllowed": 1000}}'
             )
         )
         assert (
@@ -102,6 +103,7 @@ class TestLnurlPayResponse:
                 "minSendable": 1000,
                 "maxSendable": 2000,
                 "metadata": metadata,
+                "commentAllowed": 1000
             }
         )
         assert res.dict(by_alias=False) == {
@@ -110,6 +112,7 @@ class TestLnurlPayResponse:
             "min_sendable": 1000,
             "max_sendable": 2000,
             "metadata": metadata,
+            "comment_allowed": 1000
         }
 
     @pytest.mark.parametrize(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -132,8 +132,20 @@ class TestLnurlPayResponseComment:
     @pytest.mark.parametrize(
         "d",
         [
-            {"callback": "https://service.io/pay", "min_sendable": 1000, "max_sendable": 2000, "metadata": metadata},
-            {"callback": "https://service.io/pay", "minSendable": 1000, "maxSendable": 2000, "metadata": metadata},
+            {
+                "callback": "https://service.io/pay",
+                "min_sendable": 1000,
+                "max_sendable": 2000,
+                "metadata": metadata,
+                "comment_allowed": 555,
+            },
+            {
+                "callback": "https://service.io/pay",
+                "minSendable": 1000,
+                "maxSendable": 2000,
+                "metadata": metadata,
+                "comment_allowed": 555,
+            },
         ],
     )
     def test_success_response(self, d):
@@ -145,7 +157,7 @@ class TestLnurlPayResponseComment:
             == (
                 f'{{"tag": "payRequest", "callback": "https://service.io/pay", '
                 f'"minSendable": 1000, "maxSendable": 2000, "metadata": {json.dumps(metadata)}, '
-                f'"commentAllowed": 1000}}'
+                f'"commentAllowed": 555}}'
             )
         )
         assert (
@@ -157,7 +169,7 @@ class TestLnurlPayResponseComment:
                 "minSendable": 1000,
                 "maxSendable": 2000,
                 "metadata": metadata,
-                "commentAllowed": 1000,
+                "commentAllowed": 555,
             }
         )
         assert res.dict(by_alias=False) == {
@@ -166,7 +178,7 @@ class TestLnurlPayResponseComment:
             "min_sendable": 1000,
             "max_sendable": 2000,
             "metadata": metadata,
-            "comment_allowed": 1000,
+            "comment_allowed": 555,
         }
 
     @pytest.mark.parametrize(
@@ -177,6 +189,13 @@ class TestLnurlPayResponseComment:
             {"callback": "https://service.io/pay", "min_sendable": 0, "max_sendable": 0, "metadata": metadata},  # 0
             {"callback": "https://service.io/pay", "minSendable": 100, "maxSendable": 10, "metadata": metadata},  # max
             {"callback": "https://service.io/pay", "minSendable": -90, "maxSendable": -10, "metadata": metadata},
+            {
+                "callback": "https://service.io/pay",
+                "minSendable": 100,
+                "maxSendable": 1000,
+                "metadata": metadata,
+                "comment_allowed": "Yes",    # str should be int
+            },
         ],
     )
     def test_invalid_data(self, d):


### PR DESCRIPTION
Signed-off-by: Brian of London (Dot) <brian@v4v.app>

Added `comment_allowed` field to LnurlPayResponse and modified tests.

Refrences #10 