### PR TITLE
refactor: breaking change `decode()` now return `Lnurl`

### DIFF
--- a/lnurl/core.py
+++ b/lnurl/core.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 import httpx
 from bolt11 import Bolt11Exception, MilliSatoshi
@@ -15,15 +15,15 @@ from .models import (
     LnurlResponseModel,
     LnurlWithdrawResponse,
 )
-from .types import ClearnetUrl, DebugUrl, LnAddress, Lnurl, OnionUrl
+from .types import LnAddress, Lnurl
 
 USER_AGENT = "lnbits/lnurl"
 TIMEOUT = 5
 
 
-def decode(bech32_lnurl: str) -> Union[OnionUrl, ClearnetUrl, DebugUrl]:
+def decode(bech32_lnurl: str) -> Lnurl:
     try:
-        return Lnurl(bech32_lnurl).url
+        return Lnurl(bech32_lnurl)
     except (ValidationError, ValueError):
         raise InvalidLnurl
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -28,7 +28,9 @@ class TestDecode:
         ],
     )
     def test_decode(self, bech32, url):
-        decoded_url = decode(bech32)
+        decoded = decode(bech32)
+        assert isinstance(decoded, Lnurl)
+        decoded_url = decoded.url
         assert isinstance(decoded_url, Url)
         assert decoded_url == str(decoded_url) == url
         assert decoded_url.host == "service.io"


### PR DESCRIPTION
returning an Union type here is a big mistake, because its tricky to access the actual useful Lnurl class.

there is a chance it does not break anthing because usually it was used like: `str(url)` because it was of `Url` type anyway, and __str__ of Lnurl should give the same results.