### PR TITLE
chore: remove Millisats from types breaking change

### DIFF
--- a/lnurl/types.py
+++ b/lnurl/types.py
@@ -20,10 +20,6 @@ from pydantic.validators import str_validator
 from .exceptions import InvalidLnurlPayMetadata
 from .helpers import _bech32_decode, _lnurl_clean, lnurl_decode
 
-# needed for old lnbits extension imports
-# TODO: should be changed in extension to root package
-from .models import MilliSatoshi
-
 
 def ctrl_characters_validator(value: str) -> str:
     """Checks for control characters (unicode blocks C0 and C1, plus DEL)."""
@@ -292,6 +288,3 @@ class CiphertextBase64(ConstrainedStr):
 
 class Max144Str(ConstrainedStr):
     max_length = 144
-
-
-__all__ = ["MilliSatoshi"]


### PR DESCRIPTION
some old extensions where using them, most likly not anymore