### PR TITLE
feat: add LUD-17 support, refactor `Url` class - breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Check out the LUDS repository: [luds](https://github.com/lnurl/luds/)
 - [x] LUD-14
 - [x] LUD-15
 - [x] LUD-16
-- [ ] LUD-17
+- [x] LUD-17
 - [ ] LUD-18
 - [x] LUD-19
 - [x] LUD-20

--- a/lnurl/__init__.py
+++ b/lnurl/__init__.py
@@ -2,6 +2,14 @@
 from bolt11 import MilliSatoshi
 
 from .core import decode, encode, execute, execute_login, execute_pay_request, execute_withdraw, get, handle
+from .exceptions import (
+    InvalidLnurl,
+    InvalidLnurlPayMetadata,
+    InvalidUrl,
+    LnAddressError,
+    LnurlException,
+    LnurlResponseException,
+)
 from .helpers import (
     LUD13_PHRASE,
     aes_decrypt,
@@ -33,16 +41,15 @@ from .models import (
 )
 from .types import (
     Bech32,
+    CallbackUrl,
     CiphertextBase64,
-    ClearnetUrl,
-    DebugUrl,
     InitializationVectorBase64,
     LightningInvoice,
     LightningNodeUri,
     LnAddress,
     Lnurl,
     LnurlPayMetadata,
-    OnionUrl,
+    Url,
 )
 
 __all__ = [
@@ -70,9 +77,8 @@ __all__ = [
     "LnurlSuccessResponse",
     "LnurlWithdrawResponse",
     "MilliSatoshi",
-    "OnionUrl",
-    "ClearnetUrl",
-    "DebugUrl",
+    "CallbackUrl",
+    "Url",
     "LightningNodeUri",
     "LnAddress",
     "LightningInvoice",
@@ -91,4 +97,10 @@ __all__ = [
     "lnurlauth_message_to_sign",
     "lnurlauth_derive_linking_key_sign_message",
     "LUD13_PHRASE",
+    "LnurlException",
+    "LnAddressError",
+    "InvalidLnurl",
+    "InvalidLnurlPayMetadata",
+    "InvalidUrl",
+    "LnurlResponseException",
 ]

--- a/lnurl/core.py
+++ b/lnurl/core.py
@@ -77,7 +77,7 @@ async def handle(
         raise InvalidLnurl
 
     if lnurl.is_login:
-        return LnurlAuthResponse(callback=lnurl.url, k1=lnurl.url.query_params["k1"])
+        return LnurlAuthResponse(callback=lnurl.callback_url, k1=lnurl.url.query_params["k1"])
 
     return await get(lnurl.url, response_class=response_class, user_agent=user_agent, timeout=timeout)
 

--- a/lnurl/exceptions.py
+++ b/lnurl/exceptions.py
@@ -2,6 +2,10 @@ class LnurlException(Exception):
     """A LNURL error occurred."""
 
 
+class LnAddressError(LnurlException):
+    """An error ocurred processing LNURL address."""
+
+
 class LnurlResponseException(LnurlException):
     """An error ocurred processing LNURL response."""
 

--- a/lnurl/models.py
+++ b/lnurl/models.py
@@ -8,9 +8,8 @@ from pydantic import BaseModel, Field, ValidationError, validator
 
 from .exceptions import LnurlResponseException
 from .types import (
+    CallbackUrl,
     CiphertextBase64,
-    ClearnetUrl,
-    DebugUrl,
     InitializationVectorBase64,
     LightningInvoice,
     LightningNodeUri,
@@ -18,7 +17,7 @@ from .types import (
     Lnurl,
     LnurlPayMetadata,
     Max144Str,
-    OnionUrl,
+    Url,
 )
 
 
@@ -39,7 +38,7 @@ class MessageAction(LnurlPaySuccessAction):
 
 class UrlAction(LnurlPaySuccessAction):
     tag: Literal["url"] = "url"
-    url: Union[ClearnetUrl, OnionUrl, DebugUrl]
+    url: Url
     description: Max144Str
 
 
@@ -92,7 +91,7 @@ class LnurlSuccessResponse(LnurlResponseModel):
 # LUD-04: auth base spec.
 class LnurlAuthResponse(LnurlResponseModel):
     tag: Literal["login"] = "login"
-    callback: Union[ClearnetUrl, OnionUrl, DebugUrl]
+    callback: CallbackUrl
     k1: str
 
 
@@ -100,7 +99,7 @@ class LnurlAuthResponse(LnurlResponseModel):
 class LnurlChannelResponse(LnurlResponseModel):
     tag: Literal["channelRequest"] = "channelRequest"
     uri: LightningNodeUri
-    callback: Union[ClearnetUrl, OnionUrl, DebugUrl]
+    callback: CallbackUrl
     k1: str
 
 
@@ -114,7 +113,7 @@ class LnurlHostedChannelResponse(LnurlResponseModel):
 
 class LnurlPayResponse(LnurlResponseModel):
     tag: Literal["payRequest"] = "payRequest"
-    callback: Union[ClearnetUrl, OnionUrl, DebugUrl]
+    callback: CallbackUrl
     min_sendable: MilliSatoshi = Field(..., alias="minSendable", gt=0)
     max_sendable: MilliSatoshi = Field(..., alias="maxSendable", gt=0)
     metadata: LnurlPayMetadata
@@ -159,13 +158,13 @@ class LnurlPayActionResponse(LnurlResponseModel):
 
 class LnurlWithdrawResponse(LnurlResponseModel):
     tag: Literal["withdrawRequest"] = "withdrawRequest"
-    callback: Union[ClearnetUrl, OnionUrl, DebugUrl]
+    callback: CallbackUrl
     k1: str
     min_withdrawable: MilliSatoshi = Field(..., alias="minWithdrawable", gt=0)
     max_withdrawable: MilliSatoshi = Field(..., alias="maxWithdrawable", gt=0)
     default_description: str = Field("", alias="defaultDescription")
     # LUD-14: balanceCheck: reusable withdrawRequests
-    balance_check: Optional[Union[ClearnetUrl, OnionUrl, DebugUrl]] = Field(None, alias="balanceCheck")
+    balance_check: CallbackUrl = Field(None, alias="balanceCheck")
     current_balance: Optional[MilliSatoshi] = Field(None, alias="currentBalance")
     # LUD-19: Pay link discoverable from withdraw link.
     pay_link: Optional[Union[LnAddress, Lnurl]] = Field(None, alias="payLink")

--- a/lnurl/types.py
+++ b/lnurl/types.py
@@ -22,15 +22,13 @@ from .helpers import _bech32_decode, _lnurl_clean, url_decode, url_encode
 
 
 class ReprMixin:
-    __slots__ = ()
-
     def __repr__(self) -> str:
         attrs = [  # type: ignore
             outer_slot  # type: ignore
-            for outer_slot in self.__slots__  # type: ignore
-            if not outer_slot.startswith("_") and getattr(self, outer_slot) is not None  # type: ignore
+            for outer_slot in [slot for slot in self.__slots__ if not slot.startswith("_")]  # type: ignore
+            if getattr(self, outer_slot)  # type: ignore
         ]  # type: ignore
-        extra = ", " + ", ".join(f"{n}={getattr(self, n).__repr__()}" for n in attrs) if attrs else ""  # type: ignore
+        extra = ", " + ", ".join(f"{n}={getattr(self, n).__repr__()}" for n in attrs) if attrs else ""
         return f"{self.__class__.__name__}({super().__repr__()}{extra})"
 
 
@@ -88,8 +86,6 @@ def valid_lnurl_host(url: str) -> AnyUrl:
 
 
 class Url(AnyUrl):
-    """URL with extra validations over pydantic's `HttpUrl`."""
-
     max_length = 2047  # https://stackoverflow.com/questions/417142/
 
     # LUD-17: Protocol schemes and raw (non bech32-encoded) URLs.
@@ -118,7 +114,7 @@ class Url(AnyUrl):
 
 
 class CallbackUrl(Url):
-    """URL for callback purposes."""
+    """URL for callbacks. exlude lud17 schemes."""
 
     allowed_schemes = {"https", "http"}
 

--- a/lnurl/types.py
+++ b/lnurl/types.py
@@ -164,6 +164,7 @@ class Lnurl(ReprMixin, str):
         url, bech32 = self.clean(lightning)
         self.url = url
         self.bech32 = bech32
+        return str.__init__(bech32 or url)
 
     @classmethod
     def __get_validators__(cls):

--- a/lnurl/types.py
+++ b/lnurl/types.py
@@ -166,11 +166,6 @@ class Lnurl(ReprMixin, str):
         self.bech32 = bech32
 
     @classmethod
-    def __get_bech32__(cls, url: Url) -> Bech32:
-        bech32: str = url_encode(url)
-        return parse_obj_as(Bech32, bech32)
-
-    @classmethod
     def __get_validators__(cls):
         yield str_validator
         yield cls.validate

--- a/lnurl/types.py
+++ b/lnurl/types.py
@@ -4,47 +4,33 @@ import json
 import os
 import re
 from hashlib import sha256
-from typing import List, Optional, Tuple, Union
+from typing import Generator, Optional
 from urllib.parse import parse_qs
 
 from pydantic import (
+    AnyUrl,
     ConstrainedStr,
-    HttpUrl,
     Json,
     ValidationError,
     parse_obj_as,
     validator,
 )
-from pydantic.errors import UrlHostTldError, UrlSchemeError
-from pydantic.networks import Parts
 from pydantic.validators import str_validator
 
-from .exceptions import InvalidLnurlPayMetadata
-from .helpers import _bech32_decode, _lnurl_clean, url_decode
-
-
-def ctrl_characters_validator(value: str) -> str:
-    """Checks for control characters (unicode blocks C0 and C1, plus DEL)."""
-    if re.compile(r"[\u0000-\u001f\u007f-\u009f]").search(value):
-        raise ValueError
-    return value
-
-
-def strict_rfc3986_validator(value: str) -> str:
-    """Checks for RFC3986 compliance."""
-    if re.compile(r"[^]a-zA-Z0-9._~:/?#[@!$&'()*+,;=-]").search(value):
-        raise ValueError
-    return value
+from .exceptions import InvalidLnurlPayMetadata, InvalidUrl, LnAddressError
+from .helpers import _bech32_decode, _lnurl_clean, url_decode, url_encode
 
 
 class ReprMixin:
+    __slots__ = ()
+
     def __repr__(self) -> str:
         attrs = [  # type: ignore
             outer_slot  # type: ignore
-            for outer_slot in [slot for slot in self.__slots__ if not slot.startswith("_")]  # type: ignore
-            if getattr(self, outer_slot)  # type: ignore
+            for outer_slot in self.__slots__  # type: ignore
+            if not outer_slot.startswith("_") and getattr(self, outer_slot) is not None  # type: ignore
         ]  # type: ignore
-        extra = ", " + ", ".join(f"{n}={getattr(self, n).__repr__()}" for n in attrs) if attrs else ""
+        extra = ", " + ", ".join(f"{n}={getattr(self, n).__repr__()}" for n in attrs) if attrs else ""  # type: ignore
         return f"{self.__class__.__name__}({super().__repr__()}{extra})"
 
 
@@ -56,12 +42,12 @@ class Bech32(ReprMixin, str):
     def __new__(cls, bech32: str, **_) -> "Bech32":
         return str.__new__(cls, bech32)
 
-    def __init__(self, bech32: str, *, hrp: Optional[str] = None, data: Optional[List[int]] = None):
+    def __init__(self, bech32: str, *, hrp: Optional[str] = None, data: Optional[list[int]] = None):
         str.__init__(bech32)
         self.hrp, self.data = (hrp, data) if hrp and data else self.__get_data__(bech32)
 
     @classmethod
-    def __get_data__(cls, bech32: str) -> Tuple[str, List[int]]:
+    def __get_data__(cls, bech32: str) -> tuple[str, list[int]]:
         return _bech32_decode(bech32)
 
     @classmethod
@@ -75,16 +61,50 @@ class Bech32(ReprMixin, str):
         return cls(value, hrp=hrp, data=data)
 
 
-class Url(HttpUrl):
+def ctrl_characters_validator(value: str) -> str:
+    """Checks for control characters (unicode blocks C0 and C1, plus DEL)."""
+    if re.compile(r"[\u0000-\u001f\u007f-\u009f]").search(value):
+        raise InvalidUrl("URL contains control characters.")
+    return value
+
+
+def strict_rfc3986_validator(value: str) -> str:
+    """Checks for RFC3986 compliance."""
+    if os.environ.get("LNURL_STRICT_RFC3986", "0") == "1":
+        if re.compile(r"[^]a-zA-Z0-9._~:/?#[@!$&'()*+,;=-]").search(value):
+            raise InvalidUrl("URL is not RFC3986 compliant.")
+    return value
+
+
+def valid_lnurl_host(url: str) -> AnyUrl:
+    """Validates the host part of a URL."""
+    _url = parse_obj_as(AnyUrl, url)
+    if not _url.host:
+        raise InvalidUrl("URL host is required.")
+    if _url.scheme == "http":
+        if _url.host not in ["127.0.0.1", "0.0.0.0", "localhost"] and not _url.host.endswith(".onion"):
+            raise InvalidUrl("HTTP scheme is only allowed for localhost or onion addresses.")
+    return _url
+
+
+class Url(AnyUrl):
     """URL with extra validations over pydantic's `HttpUrl`."""
 
     max_length = 2047  # https://stackoverflow.com/questions/417142/
 
+    # LUD-17: Protocol schemes and raw (non bech32-encoded) URLs.
+    allowed_schemes = {"https", "http", "lnurlc", "lnurlw", "lnurlp", "keyauth"}
+
+    @property
+    def is_lud17(self) -> bool:
+        uris = ["lnurlc", "lnurlw", "lnurlp", "keyauth"]
+        return any(self.scheme == uri for uri in uris)
+
     @classmethod
-    def __get_validators__(cls):
+    def __get_validators__(cls) -> Generator:
         yield ctrl_characters_validator
-        if os.environ.get("LNURL_STRICT_RFC3986", "0") == "1":
-            yield strict_rfc3986_validator
+        yield strict_rfc3986_validator
+        yield valid_lnurl_host
         yield cls.validate
 
     @property
@@ -97,36 +117,10 @@ class Url(HttpUrl):
         return {k: v[0] for k, v in parse_qs(self.query).items()}
 
 
-class DebugUrl(Url):
-    """Unsecure web URL, to make developers life easier."""
-
-    allowed_schemes = {"http"}
-
-    @classmethod
-    def validate_host(cls, parts: Parts) -> Tuple[str, Optional[str], str, bool]:
-        host, tld, host_type, rebuild = super().validate_host(parts)
-        if host not in ["127.0.0.1", "0.0.0.0"]:
-            raise UrlSchemeError()
-        return host, tld, host_type, rebuild
-
-
-class ClearnetUrl(Url):
-    """Secure web URL."""
-
-    allowed_schemes = {"https"}
-
-
-class OnionUrl(Url):
-    """Tor anonymous onion service."""
+class CallbackUrl(Url):
+    """URL for callback purposes."""
 
     allowed_schemes = {"https", "http"}
-
-    @classmethod
-    def validate_host(cls, parts: Parts) -> Tuple[str, Optional[str], str, bool]:
-        host, tld, host_type, rebuild = super().validate_host(parts)
-        if tld != "onion":
-            raise UrlHostTldError()
-        return host, tld, host_type, rebuild
 
 
 class LightningInvoice(Bech32):
@@ -164,21 +158,21 @@ class LightningNodeUri(ReprMixin, str):
 
 
 class Lnurl(ReprMixin, str):
-    __slots__ = ("bech32", "url")
+    __slots__ = ("url", "bech32")
 
-    def __new__(cls, lightning: str, **_) -> Lnurl:
-        return str.__new__(cls, _lnurl_clean(lightning))
+    def __new__(cls, lightning: str) -> Lnurl:
+        url, bech32 = cls.clean(lightning)
+        return str.__new__(cls, bech32 or url)
 
-    def __init__(self, lightning: str, *, url: Optional[Union[OnionUrl, ClearnetUrl, DebugUrl]] = None):
-        bech32 = _lnurl_clean(lightning)
-        str.__init__(bech32)
-        self.bech32 = Bech32(bech32)
-        self.url = url if url else self.__get_url__(bech32)
+    def __init__(self, lightning: str):
+        url, bech32 = self.clean(lightning)
+        self.url = url
+        self.bech32 = bech32
 
     @classmethod
-    def __get_url__(cls, bech32: str) -> Union[OnionUrl, ClearnetUrl, DebugUrl]:
-        url: str = url_decode(bech32)
-        return parse_obj_as(Union[OnionUrl, ClearnetUrl, DebugUrl], url)  # type: ignore
+    def __get_bech32__(cls, url: Url) -> Bech32:
+        bech32: str = url_encode(url)
+        return parse_obj_as(Bech32, bech32)
 
     @classmethod
     def __get_validators__(cls):
@@ -186,8 +180,29 @@ class Lnurl(ReprMixin, str):
         yield cls.validate
 
     @classmethod
-    def validate(cls, value: str) -> Lnurl:
-        return cls(value, url=cls.__get_url__(value))
+    def clean(cls, lightning: str) -> tuple[Url, Bech32 | None]:
+        lightning = _lnurl_clean(lightning)
+        if lightning.lower().startswith("lnurl1"):
+            bech32 = parse_obj_as(Bech32, lightning)
+            url = parse_obj_as(Url, url_decode(lightning))
+        else:
+            url = parse_obj_as(Url, lightning)
+            if url.is_lud17:
+                # LUD-17: Protocol schemes and raw (non bech32-encoded) URLs.
+                # no bech32 encoding for lud17
+                bech32 = None
+            else:
+                bech32 = parse_obj_as(Bech32, url_encode(url))
+        return url, bech32
+
+    @classmethod
+    def validate(cls, lightning: str) -> Lnurl:
+        _ = cls.clean(lightning)
+        return cls(lightning)
+
+    @property
+    def callback_url(self) -> CallbackUrl:
+        return parse_obj_as(CallbackUrl, self.url)
 
     # LUD-04: auth base spec.
     @property
@@ -207,23 +222,28 @@ class Lnurl(ReprMixin, str):
             and q.get("callback") is not None
         )
 
+    # LUD-17: Protocol schemes and raw (non bech32-encoded) URLs.
+    @property
+    def is_lud17(self) -> bool:
+        return self.url.is_lud17
+
 
 class LnAddress(ReprMixin, str):
     """Lightning address of form `user@host`"""
 
     slots = ("address", "url")
 
-    def __new__(cls, address: str, **_) -> LnAddress:
+    def __new__(cls, address: str) -> LnAddress:
         return str.__new__(cls, address)
 
     def __init__(self, address: str):
         str.__init__(address)
         if not self.is_valid_lnaddress(address):
-            raise ValueError("Invalid Lightning address.")
+            raise LnAddressError("Invalid Lightning address.")
         self.address = address
         self.url = self.__get_url__(address)
 
-    # LUD-16: Paying to static internet identifiers.
+    # LUD-16: Paying to static internet identifiers.
     @validator("address")
     def is_valid_lnaddress(cls, address: str) -> bool:
         # A user can then type these on a WALLET. The <username> is limited
@@ -233,10 +253,10 @@ class LnAddress(ReprMixin, str):
         return re.fullmatch(lnaddress_regex, address) is not None
 
     @classmethod
-    def __get_url__(cls, address: str) -> Union[OnionUrl, ClearnetUrl, DebugUrl]:
+    def __get_url__(cls, address: str) -> CallbackUrl:
         name, domain = address.split("@")
         url = ("http://" if domain.endswith(".onion") else "https://") + domain + "/.well-known/lnurlp/" + name
-        return parse_obj_as(Union[OnionUrl, ClearnetUrl, DebugUrl], url)  # type: ignore
+        return parse_obj_as(CallbackUrl, url)
 
 
 class LnurlPayMetadata(ReprMixin, str):
@@ -256,14 +276,14 @@ class LnurlPayMetadata(ReprMixin, str):
     def __new__(cls, json_str: str, **_) -> LnurlPayMetadata:
         return str.__new__(cls, json_str)
 
-    def __init__(self, json_str: str, *, json_obj: Optional[List] = None):
+    def __init__(self, json_str: str, *, json_obj: Optional[list] = None):
         str.__init__(json_str)
         self._list = json_obj if json_obj else self.__validate_metadata__(json_str)
 
     @classmethod
-    def __validate_metadata__(cls, json_str: str) -> List[Tuple[str, str]]:
+    def __validate_metadata__(cls, json_str: str) -> list[tuple[str, str]]:
         try:
-            parse_obj_as(Json[List[Tuple[str, str]]], json_str)
+            parse_obj_as(Json[list[tuple[str, str]]], json_str)
             data = [(str(item[0]), str(item[1])) for item in json.loads(json_str)]
         except ValidationError:
             raise InvalidLnurlPayMetadata
@@ -306,10 +326,10 @@ class LnurlPayMetadata(ReprMixin, str):
         return output
 
     @property
-    def images(self) -> List[Tuple[str, str]]:
+    def images(self) -> list[tuple[str, str]]:
         return [x for x in self._list if x[0].startswith("image/")]
 
-    def list(self) -> List[Tuple[str, str]]:
+    def list(self) -> list[tuple[str, str]]:
         return self._list
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -113,32 +113,32 @@ class TestLightningNode:
 
 class TestLnurl:
     @pytest.mark.parametrize(
-        "lightning, url",
+        "lightning",
         [
             (
-                (
-                    "LNURL1DP68GURN8GHJ7UM9WFMXJCM99E5K7TELWY7NXENRXVMRGDTZXSENJCM98PJNWE3JX56NXCFK89JN2V3K"
-                    "XUCRSVTY8YMXGCMYXV6RQD3EXDSKVCTZV5CRGCN9XA3RQCMRVSCNWWRYVCYAE0UU"
-                ),
-                "https://service.io/?q=3fc3645b439ce8e7f2553a69e5267081d96dcd340693afabe04be7b0ccd178df",
+                "LNURL1DP68GURN8GHJ7UM9WFMXJCM99E5K7TELWY7NXENRXVMRGDTZXSENJCM98PJNWE3JX56NXCFK89JN2V3K"
+                "XUCRSVTY8YMXGCMYXV6RQD3EXDSKVCTZV5CRGCN9XA3RQCMRVSCNWWRYVCYAE0UU"
             ),
             (
-                (
-                    "lightning:LNURL1DP68GURN8GHJ7UM9WFMXJCM99E5K7TELWY7NXENRXVMRGDTZXSENJCM98PJNWE3JX56NXCFK89JN2V3K"
-                    "XUCRSVTY8YMXGCMYXV6RQD3EXDSKVCTZV5CRGCN9XA3RQCMRVSCNWWRYVCYAE0UU"
-                ),
-                "https://service.io/?q=3fc3645b439ce8e7f2553a69e5267081d96dcd340693afabe04be7b0ccd178df",
+                "lightning:LNURL1DP68GURN8GHJ7UM9WFMXJCM99E5K7TELWY7NXENRXVMRGDTZXSENJCM98PJNWE3JX56NXCFK89JN2V3K"
+                "XUCRSVTY8YMXGCMYXV6RQD3EXDSKVCTZV5CRGCN9XA3RQCMRVSCNWWRYVCYAE0UU"
             ),
+            "https://service.io",
+            "lnurlp://service.io",
         ],
     )
-    def test_valid_lnurl_and_bech32(self, lightning, url):
+    def test_valid_lnurl_and_bech32(self, lightning):
         lnurl = Lnurl(lightning)
-        # assert lnurl == lnurl.bech32
-        assert lnurl == _lnurl_clean(lightning)
         assert lnurl == parse_obj_as(Lnurl, lightning)
-        assert lnurl.bech32.hrp == "lnurl"
-        assert lnurl.url == url
-        assert lnurl.url.query_params == {"q": "3fc3645b439ce8e7f2553a69e5267081d96dcd340693afabe04be7b0ccd178df"}
+        assert lnurl.bech32 == _lnurl_clean(lightning) or lnurl.url == _lnurl_clean(lightning)
+        if lnurl.is_lud17:
+            assert lnurl.bech32 is None
+            assert lnurl == lnurl.url
+        else:
+            assert lnurl.bech32 is not None
+            assert lnurl.bech32.hrp == "lnurl"
+            assert lnurl == lnurl.bech32
+
         assert lnurl.is_login is False
 
     @pytest.mark.parametrize(
@@ -161,7 +161,7 @@ class TestLnurl:
         "url",
         [
             "http://service.io",
-            "lnurlx://service.io" "lnurlp://service.io",
+            "lnurlx://service.io",
         ],
     )
     def test_invalid_lnurl(self, url: str):


### PR DESCRIPTION
- add LUD-17 support

## BREAKING CHANGE
- simpler validation of urls
- introduction of `CallbackUrl`
now instead of using
```python
url = parse_obj_as(Union[OnionUrl, DebugUrl, ClearnetUrl], url) #type: ignore
```
you should use
```python
url = parse_obj_as(CallbackUrl, url)
```