### PR TITLE
refactor: get rid of `callback_url` on `Lnurl`

### DIFF
--- a/lnurl/core.py
+++ b/lnurl/core.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 import httpx
 from bolt11 import Bolt11Exception, MilliSatoshi
 from bolt11 import decode as bolt11_decode
-from pydantic import ValidationError
+from pydantic import ValidationError, parse_obj_as
 
 from .exceptions import InvalidLnurl, InvalidUrl, LnurlResponseException
 from .helpers import (
@@ -21,7 +21,7 @@ from .models import (
     LnurlResponseModel,
     LnurlWithdrawResponse,
 )
-from .types import LnAddress, Lnurl
+from .types import CallbackUrl, LnAddress, Lnurl
 
 USER_AGENT = "lnbits/lnurl"
 TIMEOUT = 5
@@ -84,9 +84,10 @@ async def handle(
         raise InvalidLnurl
 
     if lnurl.is_login:
-        return LnurlAuthResponse(callback=lnurl.callback_url, k1=lnurl.url.query_params["k1"])
+        callback_url = parse_obj_as(CallbackUrl, lnurl.url)
+        return LnurlAuthResponse(callback=callback_url, k1=lnurl.url.query_params["k1"])
 
-    return await get(lnurl.callback_url, response_class=response_class, user_agent=user_agent, timeout=timeout)
+    return await get(lnurl.url, response_class=response_class, user_agent=user_agent, timeout=timeout)
 
 
 async def execute(

--- a/lnurl/types.py
+++ b/lnurl/types.py
@@ -110,7 +110,7 @@ class Url(AnyUrl):
         if self.is_lud17:
             scheme = "https"
         hostport = f"{self.host}:{self.port}" if self.port else self.host
-        return f"{scheme}://{hostport}{self.path or ''}"
+        return f"{scheme}://{hostport}{self.path or ''}{self.query}"
 
     @property
     def query_params(self) -> dict:
@@ -158,7 +158,7 @@ class LightningNodeUri(ReprMixin, str):
 
 
 class Lnurl(ReprMixin, str):
-    __slots__ = ("url", "bech32")
+    __slots__ = ("url", "bech32", "lud17")
 
     def __new__(cls, lightning: str) -> Lnurl:
         url, bech32 = cls.clean(lightning)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -171,9 +171,9 @@ class TestLnurl:
         assert _lnurl.is_lud17 is True
         assert _lnurl.bech32 is None
         _url = url.replace("lnurlp://", "https://")
-        _url =_url.replace("lnurlc://", "https://")
-        _url =_url.replace("lnurlw://", "https://")
-        _url =_url.replace("keyauth://", "https://")
+        _url = _url.replace("lnurlc://", "https://")
+        _url = _url.replace("lnurlw://", "https://")
+        _url = _url.replace("keyauth://", "https://")
         assert str(_lnurl.url) == _url
         assert str(_lnurl) == _url
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -17,7 +17,6 @@ from lnurl import (
     LnurlPayResponsePayerDataOption,
     LnurlPayResponsePayerDataOptionAuth,
 )
-from lnurl.helpers import _lnurl_clean
 
 
 class TestUrl:
@@ -29,7 +28,7 @@ class TestUrl:
     def test_parameters(self, hostport):
         url = parse_obj_as(CallbackUrl, f"https://{hostport}/?q=3fc3645b439ce8e7&test=ok")
         assert url.host == "service.io"
-        assert url.base == f"https://{hostport}/"
+        assert url == f"https://{hostport}/?q=3fc3645b439ce8e7&test=ok"
         assert url.query_params == {"q": "3fc3645b439ce8e7", "test": "ok"}
 
     @pytest.mark.parametrize(
@@ -130,28 +129,34 @@ class TestLnurl:
                 "lightning:LNURL1DP68GURN8GHJ7UM9WFMXJCM99E5K7TELWY7NXENRXVMRGDTZXSENJCM98PJNWE3JX56NXCFK89JN2V3K"
                 "XUCRSVTY8YMXGCMYXV6RQD3EXDSKVCTZV5CRGCN9XA3RQCMRVSCNWWRYVCYAE0UU"
             ),
-            "https://service.io",
-            "lnurlp://service.io",
+            "https://service.io?a=1&b=2",
+            "lnurlp://service.io?a=1&b=2",
         ],
     )
     def test_valid_lnurl_and_bech32(self, lightning):
         lnurl = Lnurl(lightning)
         assert lnurl == parse_obj_as(Lnurl, lightning)
-        assert lnurl.bech32 == _lnurl_clean(lightning) or lnurl.url == _lnurl_clean(lightning)
         if lnurl.is_lud17:
             assert lnurl.bech32 is None
-            assert lnurl == lnurl.url
+            assert lnurl.lud17 == lightning
+            assert lnurl.lud17_prefix == lightning.split("://")[0]
+            assert lnurl.is_lud17 is True
+            assert lnurl.url == lightning.replace("lnurlp://", "https://")
+            assert lnurl == lightning.replace("lnurlp://", "https://")
         else:
             assert lnurl.bech32 is not None
             assert lnurl.bech32.hrp == "lnurl"
-            assert lnurl == lnurl.bech32
+            assert lnurl.bech32 == lnurl or lnurl.url == lnurl
+            assert lnurl.lud17 is None
+            assert lnurl.lud17_prefix is None
+            assert lnurl.is_lud17 is False
 
         assert lnurl.is_login is False
 
     @pytest.mark.parametrize(
         "url",
         [
-            "lnurlp://service.io",
+            "lnurlp://service.io?a=1&b=2",
             "lnurlc://service.io",
             "lnurlw://service.io",
             "keyauth://service.io",
@@ -160,10 +165,17 @@ class TestLnurl:
     def test_valid_lnurl_lud17(self, url: str):
         _lnurl = parse_obj_as(Lnurl, url)
 
+        _prefix = url.split("://")[0]
+        assert _lnurl.lud17 == url
+        assert _lnurl.lud17_prefix == _prefix
         assert _lnurl.is_lud17 is True
-        assert str(_lnurl) == url
         assert _lnurl.bech32 is None
-        assert _lnurl.callback_url == "https://service.io"
+        _url = url.replace("lnurlp://", "https://")
+        _url =_url.replace("lnurlc://", "https://")
+        _url =_url.replace("lnurlw://", "https://")
+        _url =_url.replace("keyauth://", "https://")
+        assert str(_lnurl.url) == _url
+        assert str(_lnurl) == _url
 
     @pytest.mark.parametrize(
         "url",


### PR DESCRIPTION
after some testing from @arcbtc i am reverting a bit of changed and fixing a bug

- lud17 should not the default url, instead its accessed via `is_lud17` and the property `lud17`. that mean `str(lnurl)` or `lnurl.url` is always to url to call for the client. this reverts a change introduced with https://github.com/lnbits/lnurl/pull/61/files#diff-d6db459a88b88e9c39234e72ae408ed3146f4e02fabd5cf24ff6b8a69b4b4470R196 and https://github.com/lnbits/lnurl/pull/75/
- fix: query parameters where missing extended tests
- better tests for lud17
- bech32 is now a property