### PR TITLE
fix: issue with payLink in withdraw response

### DIFF
--- a/lnurl/models.py
+++ b/lnurl/models.py
@@ -214,13 +214,14 @@ class LnurlWithdrawResponse(LnurlResponseModel):
     balanceCheck: Optional[CallbackUrl] = None
     currentBalance: Optional[MilliSatoshi] = None
     # LUD-19: Pay link discoverable from withdraw link.
-    payLink: Optional[Lnurl] = None
+    payLink: Optional[str] = None
 
     @validator("payLink", pre=True)
-    def paylink_must_be_lud17(cls, value: Optional[Lnurl] = None) -> Lnurl | None:
+    def paylink_must_be_lud17(cls, value: Optional[str] = None) -> str | None:
         if not value:
             return None
-        if value.is_lud17 and value.lud17_prefix == "lnurlp":
+        lnurl = Lnurl(value)
+        if lnurl.is_lud17 and lnurl.lud17_prefix == "lnurlp":
             return value
         raise ValueError("`payLink` must be a valid LUD17 URL (lnurlp://).")
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -260,7 +260,7 @@ class TestLnurlWithdrawResponse:
                 k1="c3RyaW5n",
                 minWithdrawable=MilliSatoshi(100),
                 maxWithdrawable=MilliSatoshi(200),
-                payLink=parse_obj_as(Lnurl, payLink),
+                payLink=payLink,
             )
 
     def test_valid_pay_link(self):
@@ -272,5 +272,5 @@ class TestLnurlWithdrawResponse:
             k1="c3RyaW5n",
             minWithdrawable=MilliSatoshi(100),
             maxWithdrawable=MilliSatoshi(200),
-            payLink=payLink,
+            payLink=payLink.lud17,
         )


### PR DESCRIPTION
after doing some testing with boltcards and payLink i think its better to use `str` instead of `Lnurl` in the responses!